### PR TITLE
fix: Replace use of Math.random with secure RNG

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -129,27 +129,49 @@ export class WordArray extends Base {
    */
   static random(nBytes) {
     const words = [];
+    let crypto = null;
+    let environment = '';
 
-    const r = (m_w) => {
-      let _m_w = m_w;
-      let _m_z = 0x3ade68b1;
-      const mask = 0xffffffff;
+    // Detect crypto implementation in browser or NodeJS
+    if (typeof window !== 'undefined' && window.crypto || window.msCrypto) {
+      // Native crypto from window (Browser)
+      // Supports experimental msCrypto in IE 11
+      crypto = window.crypto || window.msCrypto;
+      environment = 'browser';
+    } else if (typeof global !== 'undefined' && global.crypto) {
+      // Native crypto from global (NodeJS)
+      crypto = global.crypto;
+      environment = 'nodejs';
+    } else if (typeof require === 'function') {
+      // Native crypto import via require (NodeJS)
+      try {
+        crypto = require('crypto');
+        environment = 'nodejs';
+      } catch (err) {}
+    }
 
-      return () => {
-        _m_z = (0x9069 * (_m_z & 0xFFFF) + (_m_z >> 0x10)) & mask;
-        _m_w = (0x4650 * (_m_w & 0xFFFF) + (_m_w >> 0x10)) & mask;
-        let result = ((_m_z << 0x10) + _m_w) & mask;
-        result /= 0x100000000;
-        result += 0.5;
-        return result * (Math.random() > 0.5 ? 1 : -1);
-      };
+    const cryptoSecureRandomInt = () => {
+      if (environment) {
+        if (environment === 'browser') {
+          // Use getRandomValues method (Browser)
+          try {
+            return crypto.getRandomValues(new Uint32Array(1))[0];
+          } catch (err) {}
+        }
+
+        if (environment === 'nodejs') {
+          // Use randomBytes method (NodeJS)
+          try {
+            return crypto.randomBytes(4).readInt32LE();
+          } catch (err) {}
+        }
+      }
+
+      throw new Error('Native crypto module could not be used to get secure random number.');
     };
 
-    for (let i = 0, rcache; i < nBytes; i += 4) {
-      const _r = r((rcache || Math.random()) * 0x100000000);
-
-      rcache = _r() * 0x3ade67b7;
-      words.push((_r() * 0x100000000) | 0);
+    for (let i = 0; i < nBytes; i += 4) {
+      words.push(cryptoSecureRandomInt());
     }
 
     return new WordArray(words, nBytes);


### PR DESCRIPTION
Like `crypto-js` [used to until v4.0.0](https://snyk.io/vuln/SNYK-JS-CRYPTOJS-548472), this library also uses `Math.random()` for random number generation. This is insecure and can result in biased number generation. This PR fixes the vulnerability by detecting an appropriate random number generator (either `window.crypto.getRandomValues` from the browser or `crypto.randomBytes` from NodeJS) and using that as the source for random numbers (based on [the same approach used in `crypto-js`](https://github.com/brix/crypto-js/blob/90884e679206162183b979067209d51668e4751d/src/core.js#L10-L55)).

This may break environments such as IE <11 and React Native, so it should be considered a breaking change