### PR TITLE
Add correct return value to reset()

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -837,7 +837,7 @@ declare namespace CryptoES {
        *
        *     hmacHasher.reset();
        */
-      reset();
+      reset(): void;
 
       /**
        * Updates this HMAC with a message.


### PR DESCRIPTION
Otherwise I get an error: `TS7010: 'reset', which lacks return-type annotation, implicitly has an 'any' return type`.